### PR TITLE
Some minor tweaks to make it work in python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ djangocms_revolutionslider.egg-info
 .idea/
 build
 dist
+
+# Basics
+*.py[cod]
+*.pyc
+__pycache__

--- a/revolutionslider/admin.py
+++ b/revolutionslider/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
-from models import Slide
-from models import Slider
+from .models import Slide
+from .models import Slider
 
 admin.site.register(Slider)
 admin.site.register(Slide)

--- a/revolutionslider/cms_plugins.py
+++ b/revolutionslider/cms_plugins.py
@@ -17,7 +17,7 @@ class SliderRevolution(CMSPluginBase):
         # print(dir(Slider.objects))
 
         context.update({
-            'slides': instance.slide.all(),
+            'slides': instance.slides.all(),
             'url': reverse('admin:revolutionslider_slide_add')
         })
         return context

--- a/revolutionslider/cms_plugins.py
+++ b/revolutionslider/cms_plugins.py
@@ -8,7 +8,7 @@ from .models import Slider
 class SliderRevolution(CMSPluginBase):
     text_enabled = True
     allow_children = True
-    render_template = "slider.html"
+    render_template = "revolutionslider/slider.html"
     model = Slider
     name = _("Revolution Slider")
 

--- a/revolutionslider/cms_plugins.py
+++ b/revolutionslider/cms_plugins.py
@@ -2,7 +2,7 @@ from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
-from models import Slider
+from .models import Slider
 
 
 class SliderRevolution(CMSPluginBase):

--- a/revolutionslider/models.py
+++ b/revolutionslider/models.py
@@ -29,7 +29,7 @@ class Slide(CMSPlugin):
     position_x = models.IntegerField(default=477, blank=False, null=True)
     position_y = models.IntegerField(default=180, blank=False, null=True)
     easing = models.CharField(max_length=25, choices=EASE_CHOICES, default=EASE_CHOICES[0])
-    slider = models.ForeignKey('Slider', blank=True, null=True, related_name='slide')
+    slider = models.ForeignKey('Slider', blank=True, null=True, related_name='slides')
 
     def __unicode__(self):
         return "%s" % (self.id)

--- a/revolutionslider/templates/revolutionslider/slider.html
+++ b/revolutionslider/templates/revolutionslider/slider.html
@@ -3,17 +3,17 @@
     <div class="slider" id="revolutionSlider" data-slider-id="{{ instance.id }}" data-plugin-revolution-slider data-plugin-options='{"startheight": 500}'>
         <ul>
 
-            <li data-transition="fade" data-slotamount="{{instance.slides.count}}" data- data-masterspeed="300">
+            <li data-transition="fade" data-slotamount="{{ instance.slides.count }}" data- data-masterspeed="300">
                 {% for slide in slides %}
                 <img src="{{ STATIC_URL }}img/slides/slide-bg.jpg" data-bgfit="cover" data-bgposition="left top"
                      data-bgrepeat="no-repeat">
                     <div class="tp-caption randomrotate"
-                         data-x="{{slide.position_x}}"
-                         data-y="{{slide.position_y}}"
+                         data-x="{{ slide.position_x }}"
+                         data-y="{{ slide.position_y }}"
                          data-speed="{{ slide.speed }}"
                          data-start="{{ slide.start }}"
                          data-end="{{ slide.end }}"
-                         data-easing="{{slide.easing}}">
+                         data-easing="{{ slide.easing }}">
                          {% if slide.image %}
                         <img width="slide.image.width" src="{{ slide.image.url }}" alt="{{ slide.text }}">
                         {% endif %}

--- a/revolutionslider/templates/revolutionslider/slider.html
+++ b/revolutionslider/templates/revolutionslider/slider.html
@@ -14,7 +14,9 @@
                          data-start="{{ slide.start }}"
                          data-end="{{ slide.end }}"
                          data-easing="{{slide.easing}}">
+                         {% if slide.image %}
                         <img width="slide.image.width" src="{{ slide.image.url }}" alt="{{ slide.text }}">
+                        {% endif %}
                     </div>
                 {% endfor %}
             </li>


### PR DESCRIPTION
Thank you for your effort.

I might start a branch that has the slider and slide as separate plugins, so that 'slides' can be the child of a 'slider' plugin. Now you have an explicit foreign key relationship, which makes it hard to organize the order. 'slide' plugins could be drag and dropped into the right place. Are you interested in that?

D.
